### PR TITLE
Add Junjo dependency and implement smoke test workflow

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,8 @@ dependencies = [
     "elevenlabs>=0.2.27",
     "python-multipart>=0.0.6",
     "httpx>=0.27.0",
-    "numpy>=1.26.0"
+    "numpy>=1.26.0",
+    "junjo>=0.1.0"
 ]
 
 [project.optional-dependencies]

--- a/src/storytime/workflows/junjo_smoketest.py
+++ b/src/storytime/workflows/junjo_smoketest.py
@@ -1,0 +1,44 @@
+from junjo import BaseState, BaseStore, Node, Graph, Workflow
+import asyncio
+
+# Define the workflow state
+class SmokeTestState(BaseState):
+    message: str | None = None
+
+# Define the workflow store
+class SmokeTestStore(BaseStore[SmokeTestState]):
+    async def set_message(self, payload: str) -> None:
+        await self.set_state({"message": payload})
+
+# Define a node that sets a message
+class HelloNode(Node[SmokeTestStore]):
+    async def service(self, store: SmokeTestStore) -> None:
+        await store.set_message("Hello from Junjo!")
+        print("HelloNode executed.")
+
+# Instantiate the node
+hello_node = HelloNode()
+
+# Create the workflow graph (single node as both source and sink)
+graph = Graph(
+    source=hello_node,
+    sink=hello_node,
+    edges=[]
+)
+
+# Create the workflow
+workflow = Workflow[
+    SmokeTestState, SmokeTestStore
+](
+    name="Junjo Smoke Test Workflow",
+    graph=graph,
+    store=SmokeTestStore(initial_state=SmokeTestState()),
+)
+
+async def main():
+    await workflow.execute()
+    state = await workflow.get_state_json()
+    print("Final state:", state)
+
+if __name__ == "__main__":
+    asyncio.run(main()) 


### PR DESCRIPTION
- Added `junjo` as a new dependency in `pyproject.toml`.
- Created `junjo_smoketest.py` to define a simple workflow using Junjo, including a state, store, and a node that sets a message.
- Implemented an asynchronous main function to execute the workflow and print the final state.