### PR TITLE
Switch client to OpenAPI models

### DIFF
--- a/client/src/hooks/useAudioPlayer.ts
+++ b/client/src/hooks/useAudioPlayer.ts
@@ -98,8 +98,8 @@ export const useAudioPlayer = () => {
         if (audioRef.current) {
           dispatch(updateProgress({
             jobId: currentJobId,
-            position: audioRef.current.currentTime,
-            chapter: currentChapter || undefined,
+            positionSeconds: audioRef.current.currentTime,
+            currentChapterId: currentChapter || undefined,
           }));
         }
       }, 10000); // Update every 10 seconds

--- a/client/src/store/slices/authSlice.ts
+++ b/client/src/store/slices/authSlice.ts
@@ -1,9 +1,10 @@
 import { createSlice, createAsyncThunk, PayloadAction } from '@reduxjs/toolkit';
-import { User, LoginRequest, RegisterRequest, AuthResponse } from '../../types/api';
+import { AuthResponse } from '../../types/api';
+import { UserResponse, UserLogin, UserCreate } from '../../generated';
 import apiClient from '../../services/api';
 
 interface AuthState {
-  user: User | null;
+  user: UserResponse | null;
   isAuthenticated: boolean;
   isLoading: boolean;
   error: string | null;
@@ -19,7 +20,7 @@ const initialState: AuthState = {
 // Async thunks
 export const login = createAsyncThunk(
   'auth/login',
-  async (credentials: LoginRequest, { rejectWithValue }) => {
+  async (credentials: UserLogin, { rejectWithValue }) => {
     try {
       const response = await apiClient.login(credentials);
       localStorage.setItem('access_token', response.access_token);
@@ -35,7 +36,7 @@ export const login = createAsyncThunk(
 
 export const register = createAsyncThunk(
   'auth/register',
-  async (userData: RegisterRequest, { rejectWithValue }) => {
+  async (userData: UserCreate, { rejectWithValue }) => {
     try {
       const response = await apiClient.register(userData);
       localStorage.setItem('access_token', response.access_token);
@@ -127,7 +128,7 @@ const authSlice = createSlice({
 
     // Get current user
     builder
-      .addCase(getCurrentUser.fulfilled, (state, action: PayloadAction<User>) => {
+      .addCase(getCurrentUser.fulfilled, (state, action: PayloadAction<UserResponse>) => {
         state.user = action.payload;
         state.isAuthenticated = true;
       })

--- a/client/src/store/slices/jobsSlice.ts
+++ b/client/src/store/slices/jobsSlice.ts
@@ -1,10 +1,11 @@
 import { createSlice, createAsyncThunk, PayloadAction } from '@reduxjs/toolkit';
-import { Job, JobRequest, PaginatedResponse } from '../../types/api';
+import { PaginatedResponse } from '../../types/api';
+import { JobResponse, CreateJobRequest } from '../../generated';
 import apiClient from '../../services/api';
 
 interface JobsState {
-  jobs: Job[];
-  currentJob: Job | null;
+  jobs: JobResponse[];
+  currentJob: JobResponse | null;
   isLoading: boolean;
   isCreating: boolean;
   error: string | null;
@@ -71,7 +72,7 @@ export const fetchJob = createAsyncThunk(
 
 export const createJob = createAsyncThunk(
   'jobs/createJob',
-  async (jobData: JobRequest, { rejectWithValue }) => {
+  async (jobData: CreateJobRequest, { rejectWithValue }) => {
     try {
       const job = await apiClient.createJob(jobData);
       return job;
@@ -118,13 +119,13 @@ const jobsSlice = createSlice({
     clearError: (state) => {
       state.error = null;
     },
-    setCurrentJob: (state, action: PayloadAction<Job | null>) => {
+    setCurrentJob: (state, action: PayloadAction<JobResponse | null>) => {
       state.currentJob = action.payload;
     },
     setFilters: (state, action: PayloadAction<JobsState['filters']>) => {
       state.filters = action.payload;
     },
-    updateJobInList: (state, action: PayloadAction<Job>) => {
+    updateJobInList: (state, action: PayloadAction<JobResponse>) => {
       const index = state.jobs.findIndex(job => job.id === action.payload.id);
       if (index !== -1) {
         state.jobs[index] = action.payload;
@@ -132,8 +133,8 @@ const jobsSlice = createSlice({
     },
     updateJobStatus: (state, action: PayloadAction<{
       jobId: string;
-      status: Job['status'];
-      steps?: Job['steps'];
+      status: JobResponse['status'];
+      steps?: JobResponse['steps'];
     }>) => {
       const { jobId, status, steps } = action.payload;
       
@@ -162,7 +163,7 @@ const jobsSlice = createSlice({
         state.isLoading = true;
         state.error = null;
       })
-      .addCase(fetchJobs.fulfilled, (state, action: PayloadAction<PaginatedResponse<Job>>) => {
+      .addCase(fetchJobs.fulfilled, (state, action: PayloadAction<PaginatedResponse<JobResponse>>) => {
         state.isLoading = false;
         state.jobs = action.payload.items;
         state.pagination = {
@@ -183,7 +184,7 @@ const jobsSlice = createSlice({
         state.isLoading = true;
         state.error = null;
       })
-      .addCase(fetchJob.fulfilled, (state, action: PayloadAction<Job>) => {
+      .addCase(fetchJob.fulfilled, (state, action: PayloadAction<JobResponse>) => {
         state.isLoading = false;
         state.currentJob = action.payload;
         
@@ -204,7 +205,7 @@ const jobsSlice = createSlice({
         state.isCreating = true;
         state.error = null;
       })
-      .addCase(createJob.fulfilled, (state, action: PayloadAction<Job>) => {
+      .addCase(createJob.fulfilled, (state, action: PayloadAction<JobResponse>) => {
         state.isCreating = false;
         state.jobs.unshift(action.payload);
         state.currentJob = action.payload;
@@ -232,10 +233,10 @@ const jobsSlice = createSlice({
       });
 
     // Refresh job steps
-    builder
-      .addCase(refreshJobSteps.fulfilled, (state, action: PayloadAction<{
+      builder
+        .addCase(refreshJobSteps.fulfilled, (state, action: PayloadAction<{
         jobId: string;
-        steps: Job['steps'];
+        steps: JobResponse['steps'];
       }>) => {
         const { jobId, steps } = action.payload;
         

--- a/client/src/types/api.ts
+++ b/client/src/types/api.ts
@@ -1,3 +1,5 @@
+import { UserResponse } from '../generated';
+
 // API Response Types
 export interface ApiResponse<T = any> {
   data: T;
@@ -90,9 +92,11 @@ export interface RegisterRequest {
   password: string;
 }
 
+
 export interface AuthResponse {
-  user: User;
+  user: UserResponse;
   access_token: string;
+  token_type: string;
 }
 
 // Progress Types


### PR DESCRIPTION
## Summary
- integrate generated OpenAPI types in API client
- update Redux slices for new models and field names
- modify hooks to use updated progress parameters
- adjust AuthResponse type for token info

## Testing
- `pytest -q`
- `npm --prefix client run build` *(fails: missing deps)*

------
https://chatgpt.com/codex/tasks/task_e_6853b4e43e4083338b0fde99f82ae7fc