### PR TITLE
Fix Docker build entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,9 +39,7 @@ WORKDIR /app
 COPY src /app/src
 COPY alembic /app/alembic
 COPY alembic.ini /app/alembic.ini
-COPY scripts/start.sh /app/scripts/start.sh
-RUN chmod +x /app/scripts/start.sh && \
-    mkdir -p /app/static && cp -r /app/client/dist/* /app/static/
+RUN mkdir -p /app/static && cp -r /app/client/dist/* /app/static/
 
 # Expose API port
 EXPOSE 8000
@@ -50,4 +48,4 @@ EXPOSE 8000
 ENV PYTHONPATH=/app/src
 
 # Run the application
-CMD ["./scripts/start.sh"]
+CMD ["uvicorn", "storytime.api.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,13 @@ services:
     depends_on:
       - db
       - redis
-    command: ["./scripts/start.sh", "--reload"]
+    command: [
+      "uvicorn",
+      "storytime.api.main:app",
+      "--reload",
+      "--host=0.0.0.0",
+      "--port=8000"
+    ]
   worker:
     build: .
     command:


### PR DESCRIPTION
## Summary
- remove reference to `scripts/start.sh` in Dockerfile
- start the API directly via `uvicorn`
- update docker-compose command accordingly

## Testing
- `ruff format .`
- `ruff check .`
- `python -m pytest tests/ -v` *(fails: ModuleNotFoundError: No module named 'passlib')*

------
https://chatgpt.com/codex/tasks/task_e_68572f2c91dc8333a3e1a8bfcfad3a74